### PR TITLE
Import a forked SDK branch that prevents Cuda build.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/driver/HesaiLidar_SDK_2.0"]
-	path = src/driver/HesaiLidar_SDK_2.0
-	url = https://github.com/HesaiTechnology/HesaiLidar_SDK_2.0.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/driver/HesaiLidar_SDK_2.0"]
+	path = src/driver/HesaiLidar_SDK_2.0
+	url = git@github.com:Tessellate-Robotics/HesaiLidar_SDK_2.0.git


### PR DESCRIPTION
Sometimes the build got blocked for a wrong Cuda version, but we only use the CPU version. Therefore, the sudmodule SDK now points on a forked SDK version that doesn't build Cuda if Cuda is installed.